### PR TITLE
feat: 모달 개발 완료

### DIFF
--- a/components/atoms/CommonStyled.tsx
+++ b/components/atoms/CommonStyled.tsx
@@ -7,10 +7,9 @@ export interface ModalProps extends BaseLayoutProps {
 }
 
 const ModalBackground = styled.div<Pick<ModalProps, 'active'>>`
-  display: ${({ active }) => (active ? 'block' : 'none')};
+  display: ${({ active }) => (active ? 'flex' : 'none')};
   position: fixed;
   top: 0;
-  display: flex;
   justify-content: center;
   width: 100%;
   height: 100%;

--- a/components/atoms/CommonStyled.tsx
+++ b/components/atoms/CommonStyled.tsx
@@ -1,0 +1,38 @@
+import styled from 'styled-components';
+import { BaseLayoutProps } from '../../shared/const';
+
+export interface ModalProps extends BaseLayoutProps {
+  active: boolean;
+  modalType: 'big' | 'small';
+}
+
+const ModalBackground = styled.div<Pick<ModalProps, 'active'>>`
+  display: ${({ active }) => (active ? 'block' : 'none')};
+  position: fixed;
+  top: 0;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding-top: 100px;
+  background-color: ${({ theme }) => theme.color.black600};
+  z-index: 10;
+  * {
+    cursor: default;
+  }
+`;
+
+const ModalStyled = styled.div<Pick<ModalProps, 'modalType'>>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 25px;
+  padding-bottom: 40px;
+  width: 440px;
+  height: ${({ modalType }) => (modalType === 'big' ? '520px;' : '300px')};
+  background-color: #ffffff;
+  box-shadow: ${({ theme }) => theme.boxShadow.modal};
+  border-radius: 30px;
+`;
+
+export { ModalBackground, ModalStyled };

--- a/components/atoms/TextBtn.tsx
+++ b/components/atoms/TextBtn.tsx
@@ -10,6 +10,7 @@ export interface TextBtnProps
 const lightBtnStyled = css`
   background-color: ${({ theme }) => theme.color.lightViolet};
   box-shadow: ${({ theme }) => theme.boxShadow.onButton.default};
+  cursor: pointer;
   &:active {
     box-shadow: ${({ theme }) => theme.boxShadow.onButton.push};
   }
@@ -18,12 +19,12 @@ const lightBtnStyled = css`
 const darkOffBtnStyled = css`
   background-color: ${({ theme }) => theme.color.veryPeri300};
   box-shadow: ${({ theme }) => theme.boxShadow.offButton.default};
-  cursor: default;
 `;
 
 const darkOnBtnStyled = css`
   background-color: ${({ theme }) => theme.color.veryPeri};
   box-shadow: ${({ theme }) => theme.boxShadow.onButton.default};
+  cursor: pointer;
   &:active {
     box-shadow: ${({ theme }) => theme.boxShadow.onButton.push};
   }

--- a/components/moleculses/BigModal.tsx
+++ b/components/moleculses/BigModal.tsx
@@ -1,26 +1,86 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import { BaseLayoutProps } from '../../shared/const';
+import TextBtn from '../atoms/TextBtn';
 
 export interface BigModalProps extends BaseLayoutProps {
   active: boolean;
+  title: string;
+  // eslint-disable-next-line no-undef
+  contentComponent: JSX.Element;
+  leftBtnActive: boolean;
+  rightBtnActive: boolean;
+  leftBtnText: string;
+  rightBtnText: string;
 }
 
 const ModalWrapper = styled.div<Pick<BigModalProps, 'active'>>`
   display: ${({ active }) => (active ? 'block' : 'none')};
   position: fixed;
+  top: 0;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding-top: 100px;
   background-color: ${({ theme }) => theme.color.black600};
+  z-index: 10;
+  * {
+    cursor: default;
+  }
 `;
 
 const ModalStyled = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 25px;
+  padding-bottom: 40px;
   width: 440px;
   height: 520px;
+  background-color: #ffffff;
+  box-shadow: ${({ theme }) => theme.boxShadow.modal};
+  border-radius: 30px;
 `;
 
-export default function BigModal({ active, ...rest }: BigModalProps) {
+const TitleStyled = styled.div`
+  line-height: 36.31px;
+  padding-bottom: 24px;
+  font-size: 30px;
+  font-weight: 600;
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 360px;
+  padding-top: 43px;
+`;
+
+export default function BigModal({
+  active,
+  title,
+  contentComponent,
+  leftBtnActive,
+  rightBtnActive,
+  leftBtnText,
+  rightBtnText,
+  ...rest
+}: BigModalProps) {
   return (
     <ModalWrapper active={active}>
-      <ModalStyled {...rest} />
+      <ModalStyled {...rest}>
+        <TitleStyled>{title}</TitleStyled>
+        {contentComponent}
+        <ButtonWrapper>
+          <TextBtn btnType="small" active={leftBtnActive}>
+            {leftBtnText}
+          </TextBtn>
+          <TextBtn btnType="small" active={rightBtnActive}>
+            {rightBtnText}
+          </TextBtn>
+        </ButtonWrapper>
+      </ModalStyled>
     </ModalWrapper>
   );
 }

--- a/components/moleculses/BigModal.tsx
+++ b/components/moleculses/BigModal.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import styled from 'styled-components';
+import { BaseLayoutProps } from '../../shared/const';
+
+export interface BigModalProps extends BaseLayoutProps {
+  active: boolean;
+}
+
+const ModalWrapper = styled.div<Pick<BigModalProps, 'active'>>`
+  display: ${({ active }) => (active ? 'block' : 'none')};
+  position: fixed;
+  background-color: ${({ theme }) => theme.color.black600};
+`;
+
+const ModalStyled = styled.div`
+  width: 440px;
+  height: 520px;
+`;
+
+export default function BigModal({ active, ...rest }: BigModalProps) {
+  return (
+    <ModalWrapper active={active}>
+      <ModalStyled {...rest} />
+    </ModalWrapper>
+  );
+}

--- a/components/moleculses/ModalBig.tsx
+++ b/components/moleculses/ModalBig.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import styled from 'styled-components';
 import { BaseLayoutProps } from '../../shared/const';
 import TextBtn from '../atoms/TextBtn';
+import { ModalBackground, ModalStyled } from '../atoms/CommonStyled';
 
 export interface BigModalProps extends BaseLayoutProps {
   active: boolean;
@@ -13,35 +14,6 @@ export interface BigModalProps extends BaseLayoutProps {
   leftBtnText: string;
   rightBtnText: string;
 }
-
-const ModalWrapper = styled.div<Pick<BigModalProps, 'active'>>`
-  display: ${({ active }) => (active ? 'block' : 'none')};
-  position: fixed;
-  top: 0;
-  display: flex;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-  padding-top: 100px;
-  background-color: ${({ theme }) => theme.color.black600};
-  z-index: 10;
-  * {
-    cursor: default;
-  }
-`;
-
-const ModalStyled = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding-top: 25px;
-  padding-bottom: 40px;
-  width: 440px;
-  height: 520px;
-  background-color: #ffffff;
-  box-shadow: ${({ theme }) => theme.boxShadow.modal};
-  border-radius: 30px;
-`;
 
 const TitleStyled = styled.div`
   line-height: 36.31px;
@@ -57,7 +29,7 @@ const ButtonWrapper = styled.div`
   padding-top: 43px;
 `;
 
-export default function BigModal({
+export default function ModalBig({
   active,
   title,
   contentComponent,
@@ -68,8 +40,8 @@ export default function BigModal({
   ...rest
 }: BigModalProps) {
   return (
-    <ModalWrapper active={active}>
-      <ModalStyled {...rest}>
+    <ModalBackground active={active}>
+      <ModalStyled modalType="big" {...rest}>
         <TitleStyled>{title}</TitleStyled>
         {contentComponent}
         <ButtonWrapper>
@@ -81,6 +53,6 @@ export default function BigModal({
           </TextBtn>
         </ButtonWrapper>
       </ModalStyled>
-    </ModalWrapper>
+    </ModalBackground>
   );
 }

--- a/components/moleculses/ModalSmall.tsx
+++ b/components/moleculses/ModalSmall.tsx
@@ -3,16 +3,18 @@ import { BaseLayoutProps } from '../../shared/const';
 import { ModalBackground, ModalStyled } from '../atoms/CommonStyled';
 
 export interface SmallModalProps extends BaseLayoutProps {
+  active: boolean;
   // eslint-disable-next-line no-undef
   contentComponent: JSX.Element;
 }
 
 export default function ModalSmall({
+  active,
   contentComponent,
   ...rest
 }: SmallModalProps) {
   return (
-    <ModalBackground active>
+    <ModalBackground active={active}>
       <ModalStyled modalType="small" {...rest}>
         {contentComponent}
       </ModalStyled>

--- a/components/moleculses/ModalSmall.tsx
+++ b/components/moleculses/ModalSmall.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { BaseLayoutProps } from '../../shared/const';
+import { ModalBackground, ModalStyled } from '../atoms/CommonStyled';
+
+export interface SmallModalProps extends BaseLayoutProps {
+  // eslint-disable-next-line no-undef
+  contentComponent: JSX.Element;
+}
+
+export default function ModalSmall({
+  contentComponent,
+  ...rest
+}: SmallModalProps) {
+  return (
+    <ModalBackground active>
+      <ModalStyled modalType="small" {...rest}>
+        {contentComponent}
+      </ModalStyled>
+    </ModalBackground>
+  );
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,7 +4,6 @@ import { ThemeProvider } from 'styled-components';
 import { GlobalStyle } from '../styles/global-style';
 import theme from '../styles/theme';
 import wrapper from '../stores';
-import BigModal from '../components/moleculses/bigModal';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
@@ -16,7 +15,6 @@ function MyApp({ Component, pageProps }: AppProps) {
       <ThemeProvider theme={theme}>
         <Component {...pageProps} />
         <div>동작하나?</div>
-        <BigModal />
         <GlobalStyle />
       </ThemeProvider>
     </>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,21 +4,23 @@ import { ThemeProvider } from 'styled-components';
 import { GlobalStyle } from '../styles/global-style';
 import theme from '../styles/theme';
 import wrapper from '../stores';
+import BigModal from '../components/moleculses/bigModal';
 
 function MyApp({ Component, pageProps }: AppProps) {
-	return (
-		<>
-			<Head>
-				<meta name="viewport" content="width=device-width, initial-scale=1" />
-				<title>공강찾기</title>
-			</Head>
-			<ThemeProvider theme={theme}>
-				<Component {...pageProps} />
-				<div>동작하나?</div>
-				<GlobalStyle />
-			</ThemeProvider>
-		</>
-	);
+  return (
+    <>
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>공강찾기</title>
+      </Head>
+      <ThemeProvider theme={theme}>
+        <Component {...pageProps} />
+        <div>동작하나?</div>
+        <BigModal />
+        <GlobalStyle />
+      </ThemeProvider>
+    </>
+  );
 }
 
 export default wrapper.withRedux(MyApp);

--- a/styles/global-style.ts
+++ b/styles/global-style.ts
@@ -3,7 +3,9 @@ import { reset } from 'styled-reset';
 
 export const GlobalStyle = createGlobalStyle`
     ${reset}
-    box-sizing: border-box;
+    * {
+        box-sizing: border-box;
+    }
     :focus {
         outline: none;
         border: none;
@@ -12,12 +14,10 @@ export const GlobalStyle = createGlobalStyle`
         display: none;
     }
     html{
-        font-size: 11px;
         -webkit-text-size-adjust: none;
         font-family: -apple-system,BlinkMacSystemFont,helvetica,Apple SD Gothic Neo,sans-serif;
 		font-weight: 400;
         font-display: fallback;
-
         -ms-overflow-style: none;
         scrollbar-width: none;
     }


### PR DESCRIPTION
## 설명

모달 두개를 컴포넌트로 분리하였습니다. 
파일에서 나란하게 보이려고 이름을  ModalBig, ModalSmall로 했습니다.


## ModalBig props 설명

```
  active : 모달 활성화를 의미합니다.
  title : 모달 타이틀
  contentComponent: 모달 안에 들어가는 컨텐츠 컴포넌트를 넣으면 됩니다.
  leftBtnActive: 왼쪽 버튼 활성화
  rightBtnActive: 오른쪽 버튼 활성화
  leftBtnText: 왼쪽 버튼 텍스트
  rightBtnText: 오른쪽 버튼 텍스트
```


## ModalSmall props 설명
```
  active: 모달 활성화를 의미합니다.
  contentComponent: 모달 안에 들어가는 컨텐츠 컴포넌트를 넣으면 됩니다.
```

## 기타

- 두 모달에서 공통적인 스타일 부분이 있어서 원자단에 'CommonStyled' 폴더를 따로 만들었습니다.
- 원자단의 버튼 들을 모아서 Button 폴더로 분리할지 고민입니당